### PR TITLE
Allow other types than only objects as root type in RAML 1.0

### DIFF
--- a/raml-validate.js
+++ b/raml-validate.js
@@ -1,12 +1,6 @@
 var toString = Object.prototype.toString
 var ramlTypesystem = require('raml-typesystem')
 
-var RAML10_NON_OBJECT_TYPES = [
-  'any', 'array',
-  'string', 'number', 'integer', 'boolean', 'file',
-  'date-only', 'time-only', 'datetime-only', 'datetime'
-]
-
 /**
  * Check the value is a valid date.
  *
@@ -373,7 +367,7 @@ module.exports = function () {
       schema.type = schema.type[0]
     }
 
-    var isObjectType = RAML10_NON_OBJECT_TYPES.indexOf(schema.type) === -1
+    var isObjectType = !schema.type || schema.type === 'object'
     if (RAMLVersion === 'RAML10' && !isObjectType) {
       validations = validateRule(schema)
     } else {

--- a/raml-validate.js
+++ b/raml-validate.js
@@ -388,7 +388,12 @@ module.exports = function () {
       model = model || {}
       var errors = []
 
-      if (isObjectType || RAMLVersion !== 'RAML10') {
+      if (RAMLVersion === 'RAML10' && !isObjectType) {
+        var validation = validations(model, undefined, model)
+        if (!validation.valid) {
+          errors.push(validation)
+        }
+      } else {
         // Map all validations to their object and filter for failures.
         errors = Object.keys(validations).map(function (param) {
           var value = model[param]
@@ -399,11 +404,6 @@ module.exports = function () {
         }).filter(function (validation) {
           return !validation.valid
         })
-      } else {
-        var validation = validations(model, undefined, model)
-        if (!validation.valid) {
-          errors.push(validation)
-        }
       }
 
       return {

--- a/test.js
+++ b/test.js
@@ -1024,6 +1024,113 @@ var RAML10TESTS = [
     }]
   ],
   /**
+   * Non-object root elements
+   */
+  [
+    {
+      type: 'array',
+      items: 'integer'
+    },
+    [ 1, 2, 3 ],
+    true,
+    []
+  ],
+  [
+    {
+      type: 'array',
+      items: 'integer'
+    },
+    [ 'a', 'b', 'c' ],
+    false,
+    [
+      {
+        attr: 'integer',
+        key: undefined,
+        rule: 'type',
+        valid: false,
+        value: [
+          'a',
+          'b',
+          'c'
+        ]
+      }
+    ]
+  ],
+  [
+    {
+      type: 'array',
+      items: 'integer'
+    },
+    'a',
+    false,
+    [
+      {
+        attr: 'array',
+        key: undefined,
+        rule: 'type',
+        valid: false,
+        value: 'a'
+      }
+    ]
+  ],
+  [
+    {
+      type: 'array',
+      items: 'integer'
+    },
+    7,
+    false,
+    [
+      {
+        attr: 'array',
+        key: undefined,
+        rule: 'type',
+        valid: false,
+        value: 7
+      }
+    ]
+  ],
+  [
+    { type: 'integer' },
+    7,
+    true,
+    []
+  ],
+  [
+    { type: 'integer' },
+    'a',
+    false,
+    [
+      {
+        attr: 'integer',
+        key: undefined,
+        rule: 'type',
+        valid: false,
+        value: 'a'
+      }
+    ]
+  ],
+  [
+    { type: 'string' },
+    'a',
+    true,
+    []
+  ],
+  [
+    { type: 'string' },
+    7,
+    false,
+    [
+      {
+        attr: 'string',
+        key: undefined,
+        rule: 'type',
+        valid: false,
+        value: 7
+      }
+    ]
+  ],
+  /**
    * Special cases
    */
   [


### PR DESCRIPTION
Makes it possible to use types other than `object` as root elements for validation, e.g.
```js
{
  type: 'array',
  items: 'integer'
}
```
or
```js
{
  type: 'integer'
}
```