### PR TITLE
[RAML 1.0] Validate incorrectly if property name is `type`

### DIFF
--- a/test.js
+++ b/test.js
@@ -1200,6 +1200,19 @@ var RAML10TESTS = [
         value: []
       }
     ]
+  ],
+  [
+    {
+      type: {
+        type: 'string',
+        enum: ['email', 'password']
+      }
+    },
+    {
+      type: 'email'
+    },
+    true,
+    []
   ]
 ]
 /**


### PR DESCRIPTION
This just an __*issue*__ I added the failed test case:

Schema:

```js
{
  type: {
    type: 'string',
    enum: ['email', 'password']
  }
}
```

Data:

```js
{
  type: 'email'
}
```

Test result:

<img width="554" alt="2017-07-17 12 45 49" src="https://user-images.githubusercontent.com/3001525/28249518-daf992de-6a89-11e7-9f3b-7ff9b1670fc9.png">

I think this may because [`raml-typesystem`](https://github.com/raml-org/raml-typesystem#usage) use the `type` property as a type, this is expected.